### PR TITLE
Bug fix: Cannot read properties of null (reading 'value')

### DIFF
--- a/filament-purge.js
+++ b/filament-purge.js
@@ -89,7 +89,7 @@ axios
         if (node.type == "Rule" && !diffedStyles.includes(node.prelude.value) && node.prelude.value.startsWith(".")) {
           list.remove(item);
         }
-        if (node.type == "Atrule" && !diffedKeyframes.includes(node.prelude.value) && node.name.includes("keyframes")) {
+        if (node.type == "Atrule" && node.name.includes("keyframes") && !diffedKeyframes.includes(node.prelude.value)) {
           list.remove(item);
         }
       },


### PR DESCRIPTION
If node is not `keyframes` then `node.prelude` is null

<img width="1025" alt="image" src="https://github.com/awcodes/filament-plugin-purge/assets/4498933/09927b6a-0208-4f0f-bb55-4648f04dd2c2">
